### PR TITLE
Document the Mac App Store build in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@
   <a href="https://github.com/mobrava/Clipbara/stargazers"><img src="https://img.shields.io/github/stars/mobrava/Clipbara?style=flat-square" alt="GitHub stars"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/mobrava/Clipbara?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/macOS-14%2B-blue?style=flat-square" alt="macOS 14 or later">
+  <a href="https://apps.apple.com/app/clipbara/id6803537696?mt=12"><img src="https://img.shields.io/badge/Mac%20App%20Store-free-0D96F6?style=flat-square&logo=apple&logoColor=white" alt="Clipbara on the Mac App Store"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/mobrava/Clipbara/releases/latest"><strong>Download latest release</strong></a>
+  <a href="https://apps.apple.com/app/clipbara/id6803537696?mt=12"><strong>Get it on the Mac App Store</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/mobrava/Clipbara/releases/latest"><strong>Download the DMG</strong></a>
   &nbsp;·&nbsp;
   <a href="#installation"><strong>Install with Homebrew</strong></a>
 </p>
@@ -43,7 +46,7 @@
 - **Fast search and filters:** Search clip contents, titles, or source apps, then filter by content type or date.
 - **Pinboards:** Keep important clips in named collections and organize them with drag and drop.
 - **Quick Look:** Press `Space` to preview text, images, links, files, and colors before pasting.
-- **One-click copy:** Click any clip once — it lands on your clipboard and the panel closes instantly, ready for `⌘ V`.
+- **One-click copy:** Click any clip once. It lands on your clipboard and the panel closes, ready for `⌘ V`.
 - **Keyboard-first workflow:** Search, navigate, preview, and paste without reaching for the mouse.
 - **Flexible settings:** Configure shortcuts, history size, appearance, launch at login, and excluded apps.
 - **Private by default:** Clipboard data stays on your Mac with no account, server, analytics, or tracking.
@@ -74,16 +77,20 @@
 | Price | Free, open source (GPL-3.0) | Subscription | Free, open source (MIT) |
 | Interface | Card grid with visual previews | Card grid with visual previews | Compact menu-bar list |
 | Collections | Pinboards | Pinboards | — |
-| Sync across devices | No — 100% local by design | iCloud sync | No |
+| Sync across devices | No, 100% local by design | iCloud sync | No |
 | Notarized by Apple | Yes | Yes | Yes |
 
-If you need clipboard sync across devices, Paste's subscription earns its price. If you want the card-style workflow without one — and want to read every line of code that touches your clipboard — that is why Clipbara exists.
+If you need clipboard sync across devices, Paste's subscription earns its price. Clipbara covers the other case. You get the card-style workflow without a subscription, and you can read every line of code that touches your clipboard.
 
 ## Installation
 
-Clipbara requires **macOS 14 Sonoma or later**.
+Clipbara requires **macOS 14 Sonoma or later**. It is free on both channels.
 
-### Homebrew (recommended)
+### Mac App Store
+
+[**Download Clipbara on the Mac App Store**](https://apps.apple.com/app/clipbara/id6803537696?mt=12)
+
+### Homebrew
 
 ```bash
 brew install --cask mobrava/tap/clipbara
@@ -95,7 +102,30 @@ brew install --cask mobrava/tap/clipbara
 2. Open the disk image and drag the app into **Applications**.
 3. Launch Clipbara from the Applications folder.
 
-Clipbara is signed with an Apple Developer ID and notarized by Apple (as of v1.1.11), so it opens without any security warnings.
+The DMG is signed with an Apple Developer ID and notarized by Apple (as of v1.1.11), so it opens without any security warnings.
+
+### Which build should I install?
+
+Both builds are compiled from this repository and use the same storage format.
+
+| | Mac App Store | DMG and Homebrew |
+| --- | --- | --- |
+| Price | Free | Free |
+| Updates | Through the App Store | Built-in Sparkle updater |
+| App Sandbox | On | Off |
+| New features | Arrive one review cycle later | Arrive first |
+
+If you are not sure, take the App Store build.
+
+### Moving from the DMG to the App Store build
+
+The two builds use different bundle IDs, so they keep separate histories. To carry your clips over:
+
+1. In the DMG build, open **Settings → General → Backup → Export** and save the JSON file.
+2. Install the App Store build and open **Settings → General → Backup → Import**, or use the Import button on the welcome screen.
+3. Select the exported file. Existing clips are kept and duplicates are skipped.
+
+Quit one of the two builds afterwards. Running both at once registers `⌘ ⇧ V` twice and opens two panels. The DMG channel stays supported, so migrating is optional.
 
 ## Quick start
 
@@ -103,7 +133,7 @@ Clipbara is signed with an Apple Developer ID and notarized by Apple (as of v1.1
 2. Copy anything normally with `⌘ C`.
 3. Press `⌘ ⇧ V` to open your clipboard history.
 4. Start typing to search, or use `←` and `→` to move between clips.
-5. Click a clip once to copy it — the panel closes right away, so just press `⌘ V` where you need it. Or press `Space` to preview and `Return` to copy.
+5. Click a clip once to copy it. The panel closes right away, so press `⌘ V` where you need it. Or press `Space` to preview and `Return` to copy.
 
 The global shortcuts can be changed in **Settings → Shortcuts**.
 
@@ -140,7 +170,7 @@ Clipbara is designed to keep your clipboard private:
 - **No account or backend:** There is no sign-in and no server receiving your clipboard data.
 - **No telemetry:** Clipbara does not collect analytics, tracking, or usage data.
 - **App exclusions:** Prevent selected apps, such as password managers, from being recorded.
-- **Offline core:** Capture, search, preview, and paste work without an internet connection. Network access is used only for software updates through Sparkle.
+- **Offline core:** Capture, search, preview, and paste work without an internet connection. The DMG build reaches the network only to check for updates through Sparkle, and the App Store build ships without an updater.
 
 ## Build from source
 
@@ -168,7 +198,7 @@ Build and run the `Clipbara` scheme with `⌘ R` in Xcode.
 | Interface | SwiftUI + AppKit `NSPanel` |
 | Persistence | SwiftData |
 | Global shortcuts | [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts) |
-| Updates | [Sparkle](https://github.com/sparkle-project/Sparkle) |
+| Updates | [Sparkle](https://github.com/sparkle-project/Sparkle) in the DMG build, App Store in the MAS build |
 | Project generation | [XcodeGen](https://github.com/yonaskolb/XcodeGen) |
 | Minimum target | macOS 14 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,13 @@
   <a href="https://github.com/mobrava/Clipbara/stargazers"><img src="https://img.shields.io/github/stars/mobrava/Clipbara?style=flat-square" alt="GitHub stars"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/mobrava/Clipbara?style=flat-square" alt="许可证"></a>
   <img src="https://img.shields.io/badge/macOS-14%2B-blue?style=flat-square" alt="macOS 14+">
+  <a href="https://apps.apple.com/app/clipbara/id6803537696?mt=12"><img src="https://img.shields.io/badge/Mac%20App%20Store-free-0D96F6?style=flat-square&logo=apple&logoColor=white" alt="Mac App Store 上的 Clipbara"></a>
+</p>
+
+<p align="center">
+  <a href="https://apps.apple.com/app/clipbara/id6803537696?mt=12"><strong>从 Mac App Store 下载</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/mobrava/Clipbara/releases/latest"><strong>下载 DMG</strong></a>
 </p>
 
 <p align="center">
@@ -40,7 +47,7 @@ Clipbara 是一款免费开源（GPL-3.0）的 macOS 剪贴板管理器，用原
 - **快速预览**：按 `空格` 进行 Quick Look 预览，支持全键盘操作
 - **隐私控制**：可排除指定应用（如密码管理器），历史上限可配置、自动清理
 - **对终端友好**：图片以 PNG + file URL 方式写入剪贴板，可以可靠地粘贴到 Ghostty / iTerm2（详见下方[终端中的图片剪贴](#终端中的图片剪贴)）
-- **完全本地**：基于 SwiftData 本地存储，唯一的网络请求是 Sparkle 检查更新
+- **完全本地**：基于 SwiftData 本地存储，DMG 版唯一的网络请求是 Sparkle 检查更新，App Store 版本不包含更新组件
 
 ## 截图
 
@@ -50,9 +57,15 @@ Clipbara 是一款免费开源（GPL-3.0）的 macOS 剪贴板管理器，用原
 
 ## 安装
 
-要求 **macOS 14 Sonoma 或更高版本**。
+要求 **macOS 14 Sonoma 或更高版本**，两个渠道都免费。
 
-### Homebrew（推荐）
+### Mac App Store
+
+[**从 Mac App Store 下载 Clipbara**](https://apps.apple.com/app/clipbara/id6803537696?mt=12)
+
+App Store 版开启了 App Sandbox，由 App Store 推送更新；DMG 版使用 Sparkle 自动更新，新功能会先在 DMG 上线。两个版本的 bundle ID 不同，历史记录分开存储；迁移时在旧版本中使用 **Settings → General → Backup → Export** 导出 JSON，再在新版本中 Import。两个版本同时运行会重复注册 `⌘⇧V`，请只保留一个。
+
+### Homebrew
 
 ```bash
 brew install --cask mobrava/tap/clipbara
@@ -62,7 +75,7 @@ brew install --cask mobrava/tap/clipbara
 
 从 [GitHub Releases](https://github.com/mobrava/Clipbara/releases/latest) 下载最新 `.dmg`，拖入「应用程序」文件夹。
 
-应用已使用 Apple Developer ID 签名并通过 Apple 公证（自 v1.1.11 起），首次启动不会出现安全提示。
+DMG 已使用 Apple Developer ID 签名并通过 Apple 公证（自 v1.1.11 起），首次启动不会出现安全提示。
 
 ## 终端中的图片剪贴
 


### PR DESCRIPTION
Clipbara 1.3.0 is live on the Mac App Store (free), so the READMEs now cover it.

- Mac App Store badge and download link in the header of both READMEs
- New "Mac App Store" install section, with Homebrew no longer labelled as the recommended path
- "Which build should I install?" table: updates, App Sandbox, and how new features reach each channel
- Migration steps from the DMG build via Settings > General > Backup > Export/Import, plus a warning that running both builds registers the panel shortcut twice
- Privacy and tech-stack notes corrected: the MAS build ships without Sparkle
- Dropped a few em dashes from existing prose while touching these files