### PR TITLE
Prewarm the history panel after launch

### DIFF
--- a/Clipbara/AppState.swift
+++ b/Clipbara/AppState.swift
@@ -40,6 +40,13 @@ final class AppState {
             self?.previewItem = nil
         }
         setupHotkey()
+
+        // Render the panel once off screen so the first hotkey press is instant.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard let self, let container = self.modelContainer else { return }
+            self.panelController.prewarm(modelContainer: container, appState: self)
+        }
     }
 
     func togglePanel() {

--- a/Clipbara/Panel/PanelController.swift
+++ b/Clipbara/Panel/PanelController.swift
@@ -31,6 +31,31 @@ final class PanelController {
         }
     }
 
+    /// Builds the panel and renders its first frame off screen so the first
+    /// hotkey press only has to animate. Called shortly after launch.
+    func prewarm(modelContainer: ModelContainer, appState: AppState) {
+        guard panel == nil else { return }
+        self.appState = appState
+
+        let screenFrame = (NSScreen.main ?? NSScreen.screens.first!).visibleFrame
+        let frame = panelFrame(in: screenFrame, itemCount: 0, y: screenFrame.origin.y)
+            .offsetBy(dx: 0, dy: -baseHeight)
+
+        let warm = ClipbaraPanel(contentRect: frame)
+        warm.alphaValue = 0
+        warm.contentView = NSHostingView(
+            rootView: HistoryPanelView()
+                .environment(appState)
+                .modelContainer(modelContainer)
+        )
+        warm.orderFrontRegardless()
+        warm.contentView?.layoutSubtreeIfNeeded()
+        warm.displayIfNeeded()
+        warm.orderOut(nil)
+        warm.alphaValue = 1
+        panel = warm
+    }
+
     func showPanel(modelContainer: ModelContainer, appState: AppState) {
         guard !isVisible else { return }
         self.appState = appState


### PR DESCRIPTION
## Problem

After quitting and relaunching, the panel appeared to need three presses of `Cmd+Shift+V`.

Measured with os_log timestamps on a real launch:

```
35.632  hotkey fired  -> isVisible=false -> show
35.802  cold render done (fetchCount 5.6ms, hosting 50ms, layout 76ms = 168ms total)
        ... 250ms reveal animation starts here
36.026  hotkey fired  -> isVisible=true  -> hide   (panel was still sliding in)
36.538  hotkey fired  -> show (13ms, warm) -> finally visible
```

Every press registered correctly, so this was never a hotkey problem. The panel window is transparent until SwiftUI renders its first frame, so for the first ~170ms nothing was on screen. Total time to a visible panel was about 420ms, longer than the interval between two presses, so the second press cancelled the reveal.

## Fix

Render the panel once off screen 300ms after launch (`alphaValue = 0`, ordered front, laid out, ordered out), so the first press only pays for the animation.

## Verification

Rebuilt and tested on macOS with nine real key presses:

```
30.842  prewarm-end (147ms, does not block the main thread)
31.913  fired -> isVisible=false
31.974  panel ordered in    <- 61ms, down from 168ms
33.127  fired -> isVisible=true -> closes
33.982  fired -> opens
```

First press opens it, and repeated presses alternate open/close correctly.

An earlier attempt also added a guard that ignored toggles during the reveal animation. That was dropped: with the prewarm in place the panel is visible within ~60ms, so the guard only made the panel refuse to close on a fast second press.