### PR TITLE
Show the panel on the screen under the pointer

### DIFF
--- a/Clipbara/Panel/PanelController.swift
+++ b/Clipbara/Panel/PanelController.swift
@@ -23,6 +23,30 @@ final class PanelController {
     private let contentHorizontalPadding: CGFloat = 32
     private let maximumVisibleCardCount = 6
 
+    // MARK: - Screen Selection
+
+    /// Returns the screen that contains `point`, if any.
+    ///
+    /// Kept static and dependency free so the multi display placement rules can
+    /// be exercised without attaching real hardware.
+    static func screen(containing point: NSPoint, in screens: [NSScreen]) -> NSScreen? {
+        screens.first { NSMouseInRect(point, $0.frame, false) }
+    }
+
+    /// The display the user is actually working on.
+    ///
+    /// `NSScreen.main` resolves to the screen owning the key window, not the
+    /// screen the user is looking at. Clipbara is a menu bar app and is never
+    /// the active app when the hotkey fires, so `NSScreen.main` can point at
+    /// whichever display last held focus and the panel slides in on the wrong
+    /// screen. The pointer location matches the user's intent, so prefer it and
+    /// fall back to `NSScreen.main` only when the pointer is off screen.
+    private var activeScreen: NSScreen {
+        Self.screen(containing: NSEvent.mouseLocation, in: NSScreen.screens)
+            ?? NSScreen.main
+            ?? NSScreen.screens.first!
+    }
+
     func toggle(modelContainer: ModelContainer, appState: AppState) {
         if isVisible {
             hidePanel()
@@ -37,7 +61,7 @@ final class PanelController {
         guard panel == nil else { return }
         self.appState = appState
 
-        let screenFrame = (NSScreen.main ?? NSScreen.screens.first!).visibleFrame
+        let screenFrame = activeScreen.visibleFrame
         let frame = panelFrame(in: screenFrame, itemCount: 0, y: screenFrame.origin.y)
             .offsetBy(dx: 0, dy: -baseHeight)
 
@@ -60,7 +84,7 @@ final class PanelController {
         guard !isVisible else { return }
         self.appState = appState
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let screen = activeScreen
         let screenFrame = screen.visibleFrame
         let itemCount = visibleItemCount(modelContainer: modelContainer, selectedTab: appState.selectedTab)
         let endFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: screenFrame.origin.y)
@@ -99,7 +123,7 @@ final class PanelController {
     func resizeToContentItemCount(_ itemCount: Int, animated: Bool = true) {
         guard isVisible, let panel else { return }
 
-        let screen = panel.screen ?? NSScreen.main ?? NSScreen.screens.first!
+        let screen = panel.screen ?? activeScreen
         let screenFrame = screen.visibleFrame
         let targetFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: panel.frame.origin.y)
 
@@ -135,7 +159,7 @@ final class PanelController {
         onPanelWillHide?()
         hideQuickLook()
 
-        let screenFrame = (NSScreen.main ?? NSScreen.screens.first!).visibleFrame
+        let screenFrame = (panel.screen ?? activeScreen).visibleFrame
         let panelHeight = panel.frame.height
 
         let offscreenFrame = NSRect(
@@ -380,7 +404,7 @@ final class PanelController {
         appState.selectForPreview(nil)
         quickLookItem = item
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let screen = self.panel?.screen ?? activeScreen
         let screenFrame = screen.visibleFrame
 
         let panel: ClipboardQuickLookPanel


### PR DESCRIPTION
## Problem

Reported in #20: on a dual display setup with the secondary screen placed below the primary, pressing the hotkey while on the primary screen opens the history panel on the secondary screen, sliding in from the right instead of from the bottom.

## Cause

Every placement path in `PanelController` resolved its display with `NSScreen.main`. `NSScreen.main` is the screen owning the key window, not the screen the user is working on. Clipbara is a menu bar accessory app and is never the active app when the global hotkey fires, so `NSScreen.main` can resolve to whichever display last held focus.

The odd slide direction has the same root: the start frame was derived from the wrong screen's `visibleFrame.origin.y`, so the panel animated across displays instead of up from the bottom edge.

## Fix

- Add `activeScreen`, which picks the screen containing `NSEvent.mouseLocation` and falls back to `NSScreen.main` only when the pointer is off screen.
- Use it in `prewarm`, `showPanel`, and `resizeToContentItemCount`.
- `hidePanel` and `showQuickLook` now follow the panel's own screen, so the hide animation and the Quick Look overlay stay on the display the panel was opened on.
- The screen lookup is a static, dependency free `screen(containing:in:)` so multi display placement can be checked without attaching hardware.

## Testing

- [x] Reproduced on a dual display setup (built-in Retina primary, external 4K placed below).
- [ ] Rebuild and confirm the panel opens on the pointer's screen, with the slide-up animation, in both display arrangements and with "Displays have separate Spaces" on and off.
