### PR TITLE
Fix the panel opening on the wrong display

### DIFF
--- a/Clipbara/Panel/ClipbaraPanel.swift
+++ b/Clipbara/Panel/ClipbaraPanel.swift
@@ -26,4 +26,12 @@ final class ClipbaraPanel: NSPanel {
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    /// AppKit nudges ordinary windows back inside a screen's usable area. The
+    /// panel is deliberately parked off the bottom edge while it animates, and
+    /// the default behaviour both shifts that position and re-homes the panel
+    /// to a neighbouring display. Place the panel exactly where asked.
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        frameRect
+    }
 }

--- a/Clipbara/Panel/PanelController.swift
+++ b/Clipbara/Panel/PanelController.swift
@@ -23,6 +23,30 @@ final class PanelController {
     private let contentHorizontalPadding: CGFloat = 32
     private let maximumVisibleCardCount = 6
 
+    // MARK: - Screen Selection
+
+    /// Returns the screen that contains `point`, if any.
+    ///
+    /// Kept static and dependency free so the multi display placement rules can
+    /// be exercised without attaching real hardware.
+    static func screen(containing point: NSPoint, in screens: [NSScreen]) -> NSScreen? {
+        screens.first { NSMouseInRect(point, $0.frame, false) }
+    }
+
+    /// The display the user is actually working on.
+    ///
+    /// `NSScreen.main` resolves to the screen owning the key window, not the
+    /// screen the user is looking at. Clipbara is a menu bar app and is never
+    /// the active app when the hotkey fires, so `NSScreen.main` can point at
+    /// whichever display last held focus and the panel slides in on the wrong
+    /// screen. The pointer location matches the user's intent, so prefer it and
+    /// fall back to `NSScreen.main` only when the pointer is off screen.
+    private var activeScreen: NSScreen {
+        Self.screen(containing: NSEvent.mouseLocation, in: NSScreen.screens)
+            ?? NSScreen.main
+            ?? NSScreen.screens.first!
+    }
+
     func toggle(modelContainer: ModelContainer, appState: AppState) {
         if isVisible {
             hidePanel()
@@ -37,7 +61,7 @@ final class PanelController {
         guard panel == nil else { return }
         self.appState = appState
 
-        let screenFrame = (NSScreen.main ?? NSScreen.screens.first!).visibleFrame
+        let screenFrame = activeScreen.visibleFrame
         let frame = panelFrame(in: screenFrame, itemCount: 0, y: screenFrame.origin.y)
             .offsetBy(dx: 0, dy: -baseHeight)
 
@@ -60,7 +84,7 @@ final class PanelController {
         guard !isVisible else { return }
         self.appState = appState
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let screen = activeScreen
         let screenFrame = screen.visibleFrame
         let itemCount = visibleItemCount(modelContainer: modelContainer, selectedTab: appState.selectedTab)
         let endFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: screenFrame.origin.y)
@@ -99,7 +123,7 @@ final class PanelController {
     func resizeToContentItemCount(_ itemCount: Int, animated: Bool = true) {
         guard isVisible, let panel else { return }
 
-        let screen = panel.screen ?? NSScreen.main ?? NSScreen.screens.first!
+        let screen = panel.screen ?? activeScreen
         let screenFrame = screen.visibleFrame
         let targetFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: panel.frame.origin.y)
 
@@ -135,7 +159,7 @@ final class PanelController {
         onPanelWillHide?()
         hideQuickLook()
 
-        let screenFrame = (NSScreen.main ?? NSScreen.screens.first!).visibleFrame
+        let screenFrame = (panel.screen ?? activeScreen).visibleFrame
         let panelHeight = panel.frame.height
 
         let offscreenFrame = NSRect(
@@ -380,7 +404,7 @@ final class PanelController {
         appState.selectForPreview(nil)
         quickLookItem = item
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let screen = self.panel?.screen ?? activeScreen
         let screenFrame = screen.visibleFrame
 
         let panel: ClipboardQuickLookPanel

--- a/Clipbara/Panel/PanelController.swift
+++ b/Clipbara/Panel/PanelController.swift
@@ -6,6 +6,12 @@ import SwiftData
 @Observable
 final class PanelController {
     private var panel: ClipbaraPanel?
+    /// The panel's SwiftUI content. Slid inside the fixed panel frame so the
+    /// window itself never has to travel off screen to animate.
+    private var contentHost: NSView?
+    /// The screen the panel was opened on. `panel.screen` is unreliable while
+    /// the panel sits flush against a screen edge next to another display.
+    private var presentedScreen: NSScreen?
     private var quickLookPanel: ClipboardQuickLookPanel?
     private var quickLookItem: ClipboardItem?
     private(set) var isVisible: Bool = false
@@ -61,17 +67,15 @@ final class PanelController {
         guard panel == nil else { return }
         self.appState = appState
 
+        // Build the warm panel at its real on screen position. Parking it below
+        // the screen would hand it to a display stacked underneath before the
+        // first hotkey press ever happens. It stays invisible via `alphaValue`.
         let screenFrame = activeScreen.visibleFrame
         let frame = panelFrame(in: screenFrame, itemCount: 0, y: screenFrame.origin.y)
-            .offsetBy(dx: 0, dy: -baseHeight)
 
         let warm = ClipbaraPanel(contentRect: frame)
         warm.alphaValue = 0
-        warm.contentView = NSHostingView(
-            rootView: HistoryPanelView()
-                .environment(appState)
-                .modelContainer(modelContainer)
-        )
+        warm.contentView = makeContentView(modelContainer: modelContainer, appState: appState, size: frame.size)
         warm.orderFrontRegardless()
         warm.contentView?.layoutSubtreeIfNeeded()
         warm.displayIfNeeded()
@@ -88,30 +92,48 @@ final class PanelController {
         let screenFrame = screen.visibleFrame
         let itemCount = visibleItemCount(modelContainer: modelContainer, selectedTab: appState.selectedTab)
         let endFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: screenFrame.origin.y)
-        let startFrame = endFrame.offsetBy(dx: 0, dy: -endFrame.height)
+        presentedScreen = screen
 
         if panel == nil {
-            panel = ClipbaraPanel(contentRect: startFrame)
-
-            let hostingView = NSHostingView(
-                rootView: HistoryPanelView()
-                    .environment(appState)
-                    .modelContainer(modelContainer)
+            panel = ClipbaraPanel(contentRect: endFrame)
+            panel?.contentView = makeContentView(
+                modelContainer: modelContainer,
+                appState: appState,
+                size: endFrame.size
             )
-            panel?.contentView = hostingView
         } else {
-            panel?.setFrame(startFrame, display: false)
+            panel?.setFrame(endFrame, display: false)
         }
 
+        // The panel frame stays put; the content starts one panel height below
+        // the window and rides up into it. Moving the window itself would push
+        // it onto a display stacked underneath, which is how the panel used to
+        // end up on the wrong screen.
+        contentHost?.frame.origin.y = -endFrame.height
+        panel?.alphaValue = 1
         panel?.orderFrontRegardless()
         panel?.makeKey()
         panel?.makeFirstResponder(nil)
 
-        NSAnimationContext.runAnimationGroup { context in
+        // The window shadow is derived from the content alpha. While the
+        // content is only partly inside the frame the shadow would outline
+        // empty space, so drop it for the duration of the slide.
+        panel?.hasShadow = false
+
+        NSAnimationContext.runAnimationGroup({ [contentHost] context in
             context.duration = 0.25
             context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            panel?.animator().setFrame(endFrame, display: true)
-        }
+            if let contentHost {
+                var target = contentHost.frame
+                target.origin.y = 0
+                contentHost.animator().frame = target
+            }
+        }, completionHandler: { [weak self] in
+            Task { @MainActor in
+                self?.panel?.hasShadow = true
+                self?.panel?.invalidateShadow()
+            }
+        })
 
         isVisible = true
         appState.markPanelPresented()
@@ -123,7 +145,7 @@ final class PanelController {
     func resizeToContentItemCount(_ itemCount: Int, animated: Bool = true) {
         guard isVisible, let panel else { return }
 
-        let screen = panel.screen ?? activeScreen
+        let screen = presentedScreen ?? panel.screen ?? activeScreen
         let screenFrame = screen.visibleFrame
         let targetFrame = panelFrame(in: screenFrame, itemCount: itemCount, y: panel.frame.origin.y)
 
@@ -159,27 +181,28 @@ final class PanelController {
         onPanelWillHide?()
         hideQuickLook()
 
-        let screenFrame = (panel.screen ?? activeScreen).visibleFrame
         let panelHeight = panel.frame.height
-
-        let offscreenFrame = NSRect(
-            x: panel.frame.origin.x,
-            y: screenFrame.origin.y - panelHeight,
-            width: panel.frame.width,
-            height: panelHeight
-        )
 
         removeClickMonitor()
         removeMouseMonitor()
         removeKeyMonitor()
 
-        NSAnimationContext.runAnimationGroup({ context in
+        panel.hasShadow = false
+
+        NSAnimationContext.runAnimationGroup({ [contentHost] context in
             context.duration = 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
-            panel.animator().setFrame(offscreenFrame, display: true)
+            if let contentHost {
+                var target = contentHost.frame
+                target.origin.y = -panelHeight
+                contentHost.animator().frame = target
+            }
         }, completionHandler: { [weak self] in
             Task { @MainActor in
                 panel.orderOut(nil)
+                panel.hasShadow = true
+                self?.contentHost?.frame.origin.y = 0
+                self?.presentedScreen = nil
                 self?.isVisible = false
             }
         })
@@ -474,6 +497,31 @@ final class PanelController {
             guard let pinboard = try? context.fetch(descriptor).first else { return 0 }
             return pinboard.entries.filter { !$0.isDeleted && $0.clipboardItem != nil }.count
         }
+    }
+
+    /// Wraps the SwiftUI content in a plain container so it can be offset
+    /// inside the panel. Anything pushed outside the panel frame is clipped by
+    /// the window surface, which is what makes the slide read as a reveal.
+    private func makeContentView(
+        modelContainer: ModelContainer,
+        appState: AppState,
+        size: NSSize
+    ) -> NSView {
+        let host = NSHostingView(
+            rootView: HistoryPanelView()
+                .environment(appState)
+                .modelContainer(modelContainer)
+        )
+        host.frame = NSRect(origin: .zero, size: size)
+        host.autoresizingMask = [.width]
+
+        let container = NSView(frame: NSRect(origin: .zero, size: size))
+        container.wantsLayer = true
+        container.layer?.masksToBounds = true
+        container.addSubview(host)
+
+        contentHost = host
+        return container
     }
 
     private func panelFrame(in screenFrame: NSRect, itemCount: Int, y: CGFloat) -> NSRect {


### PR DESCRIPTION
## Problem

Reported in #20: on a dual display setup with the secondary screen placed below the primary, pressing the hotkey while on the primary screen opens the history panel on the secondary screen, sliding in from the right instead of from the bottom.

## Cause

The show animation parked the panel one panel height below the bottom edge of its screen and then slid the window up into place. That position is only "off screen" when nothing is there. Logging the frames on a stacked setup showed what actually happens:

```
screens    = [ (0,0,1512,982) built-in, (-160,-1080,1920,1080) external ]
endFrame   = (75.6,    0, 1360.8, 280)   intended: bottom of the built-in screen
startFrame = (75.6, -280, 1360.8, 280)   parked below it

after orderFront  panel.frame = (75, -305, ...)  panel.screen = external
after animation   panel.frame = (80, -305, ...)  panel.screen = external
```

The parked frame lands inside the display stacked underneath. AppKit re-homes the panel to that display and then clamps every subsequent `setFrame` to it, so the animation to `endFrame` never moves the panel back up. `constrainFrameRect(_:to:)` also shifted the frame by 25pt, which is the `-280` to `-305` drift above. `resizeToContentItemCount` then re-centred the panel using `panel.screen`, pinning it to the wrong display for good.

`prewarm` created the panel at that same parked position, so the panel was bound to the lower display from launch.

## Fix

- Keep the window at its final frame for the whole presentation and slide the SwiftUI content inside it instead. The window surface clips whatever is still outside the frame, so the reveal looks unchanged while the panel never leaves its screen. `hidePanel` does the same in reverse.
- Drop the window shadow during the slide. It is derived from the content alpha and would otherwise outline empty space.
- Override `constrainFrameRect(_:to:)` in `ClipbaraPanel` so AppKit stops nudging the panel off its computed position.
- Remember the screen the panel was opened on, so content driven resizes cannot re-centre it on a neighbouring display.
- Build the prewarmed panel at its real on screen position rather than below the screen.
- Pick the screen under the pointer rather than `NSScreen.main`. `NSScreen.main` is the screen owning the key window, and Clipbara is never the active app when the global hotkey fires. This was not the cause of #20, but it is the correct source of truth for a menu bar app.

## Testing

Verified on a dual display setup (built-in Retina primary at (0,0), external 4K stacked below at y -1080):

- [x] Panel opens on the built-in screen when the pointer is there.
- [x] Panel opens on the external screen when the pointer is there.
- [x] Same slide-up motion on both screens. An earlier revision fell back to a fade on stacked setups and was reworked because the motion differed per display.
- [x] Panel closes on the screen it opened on.
