### PR TITLE
Hide the pinboard scroll indicator

### DIFF
--- a/Clipbara/Views/PinboardGridView.swift
+++ b/Clipbara/Views/PinboardGridView.swift
@@ -33,7 +33,7 @@ struct PinboardGridView: View {
                     let pinboardItems = orderedEntries.compactMap(\.clipboardItem)
 
                     ScrollViewReader { proxy in
-                        ScrollView(.horizontal, showsIndicators: true) {
+                        ScrollView(.horizontal, showsIndicators: false) {
                             LazyHGrid(rows: rows, spacing: 8) {
                                 ForEach(Array(orderedEntries.enumerated()), id: \.element.id) { index, entry in
                                     if let item = entry.clipboardItem {


### PR DESCRIPTION
## Problem

A horizontal scrollbar sits across the bottom of the panel whenever a pinboard tab is open. The history tab does not show one.

## Cause

`CardGridView` builds its scroll view with `showsIndicators: false`, but `PinboardGridView` passes `showsIndicators: true`.

## Fix

Match the history grid and hide the indicator.
