### PR TITLE
Start the panel slide after the window is on screen

### DIFF
--- a/Clipbara/Panel/PanelController.swift
+++ b/Clipbara/Panel/PanelController.swift
@@ -111,29 +111,42 @@ final class PanelController {
         // end up on the wrong screen.
         contentHost?.frame.origin.y = -endFrame.height
         panel?.alphaValue = 1
-        panel?.orderFrontRegardless()
-        panel?.makeKey()
-        panel?.makeFirstResponder(nil)
 
         // The window shadow is derived from the content alpha. While the
         // content is only partly inside the frame the shadow would outline
         // empty space, so drop it for the duration of the slide.
         panel?.hasShadow = false
 
-        NSAnimationContext.runAnimationGroup({ [contentHost] context in
-            context.duration = 0.25
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            if let contentHost {
+        panel?.orderFrontRegardless()
+        panel?.makeKey()
+        panel?.makeFirstResponder(nil)
+
+        // Ordering a window in is not instant: the window server needs a
+        // composited frame before anything reaches the screen. Starting the
+        // slide in this same turn meant the easeOut curve was already most of
+        // the way through by the time the panel actually appeared, so the
+        // content popped in instead of riding up. Push the parked first frame
+        // out now, then start the slide on the next main actor turn so the
+        // whole curve happens on screen. `hidePanel` never had this problem
+        // because its window is already visible when it animates.
+        panel?.contentView?.displayIfNeeded()
+        CATransaction.flush()
+
+        Task { @MainActor [weak self] in
+            guard let self, let contentHost = self.contentHost else { return }
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = 0.25
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 var target = contentHost.frame
                 target.origin.y = 0
                 contentHost.animator().frame = target
-            }
-        }, completionHandler: { [weak self] in
-            Task { @MainActor in
-                self?.panel?.hasShadow = true
-                self?.panel?.invalidateShadow()
-            }
-        })
+            }, completionHandler: {
+                Task { @MainActor [weak self] in
+                    self?.panel?.hasShadow = true
+                    self?.panel?.invalidateShadow()
+                }
+            })
+        }
 
         isVisible = true
         appState.markPanelPresented()


### PR DESCRIPTION
## Problem

Found while testing 1.3.1 before release: closing the panel slides down correctly, but opening it pops in. The motion is asymmetric even though `showPanel` and `hidePanel` animate the same view the same way.

## Cause

#22 moved the reveal from animating the window to sliding the content inside a fixed panel frame. `showPanel` still started that animation in the same turn as `orderFrontRegardless()`. Ordering a window in is not instant, the window server needs a composited frame before anything reaches the screen.

Instrumented a release build and logged timestamps across six open/close cycles:

```
ordered-in -> anim-start :  62, 51, 48, 60, 47, 53 ms   (mean 53)
anim-start -> anim-end   : 278, 261, 257, 261, 259, 263 ms  (duration is 250)
y at anim-start          : -280.0 every time
```

The slide is 250ms easeOut. A 53ms head start is 20% of the duration and roughly 36% of the distance on that curve, so the panel became visible already a third of the way up. `hidePanel` is unaffected because its window is already on screen when it animates.

## Fix

- Push the parked first frame to the screen with `displayIfNeeded()` and a `CATransaction.flush()` right after ordering the window in.
- Start the slide on the next main actor turn, so the whole easeOut curve happens while the panel is visible.
- Drop the window shadow before `orderFrontRegardless()` rather than after, so the first composited frame never draws a shadow around empty space.

## Cost

Content starts moving about 50ms later than before. Hotkey to fully open is about 310ms. Still far better than the 168ms of panel construction this path paid before #18.

## Testing

Release build (Developer ID, notarized), installed to /Applications, single display:

- [x] Open animation rides up the full distance, matches the close animation
- [x] Close animation unchanged
- [x] Quick Look preview
- [x] Panel resize as the visible clip count changes
- [x] Pinboard tab has no horizontal scrollbar (#23)
- [x] Dual display, secondary stacked below primary, still opens on the screen under the pointer (#20)
